### PR TITLE
feat: date-range prop input takes string

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The components accepts optional properties.
 | :hide-date-in-button | boolean | no       | true                                                       | false     | Overrides the applied date being showed in place of Button label                                                                                                                                                                                                   |
 | :show-time         | boolean | no       | false                                                      | true      | Overrides the time being shown next to the date                                                                                                                                                                                                                    |
 | :init=custom-toggle | boolean | no       | false                                                      | true      | Activates or de-activate Custom toggle at the bottom on inital open                                                                                                                                                                                                |
-| :date-range       | object  | no       | { start: new Date(), end: new Date(), showDateText: true } | true      | Allows the date-range to be past in. The obejct must include a 'start' and 'end' key with a date value. 'showDateText' (optional) must be a boolean and will over ride the button lable and message above the calender to be the date range. It defaults to false |
+| :date-range       | object  | no       | { start: new Date(), end: "2018-11-13T23:00:00.000Z", showDateText: true } | true      | Allows the date-range to be past in. The obejct must include a 'start' and 'end' key with a date value or an ISO sting. 'showDateText' (optional) must be a boolean and will over ride the button lable and message above the calender to be the date range. It defaults to false |
 
 ### Event
 
@@ -68,7 +68,7 @@ The Date picker with only return the selected date from the component when the A
 
 | Event      | type    | example              | default | description                                                                                                                   |
 |:-----------|:--------|:---------------------|:--------|:------------------------------------------------------------------------------------------------------------------------------|
-| @get-dates | fuction | (selected dates)=>{} | n/a     | Passes the selected dates when the applied button is clicked and will return an object  { start: new Date(), end: new Date()} |
+| @get-dates | fuction | (selected dates)=>{} | n/a     | Passes the selected dates when the applied button is clicked and will return an object  { start: new Date(), end: new Date(), showDateText: true} |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11101,14 +11101,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11123,20 +11121,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11253,8 +11248,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11266,7 +11260,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11281,7 +11274,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11289,14 +11281,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -11315,7 +11305,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11396,8 +11385,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11409,7 +11397,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11531,7 +11518,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,19 @@
         :date-range="selectedDate"
         @get-dates="printTheDate"/>
     </div>
+    <div>
+      <h3>String&nbsp;Input</h3>
+      <vue-date-picker
+        locale="en"
+        tint-color="#357ebd"
+        button-label="All Time"
+        button-width="auto"
+        :hide-date-in-button="false"
+        :show-time="true"
+        :init-custom-toggle="true"
+        :date-range="stringDateRang"
+        @get-dates="setStringDateRange"/>
+    </div>
   </div>
 </template>
 
@@ -73,10 +86,15 @@ export default {
   },
   data () {
     const date = new Date()
+    const start = new Date(date.getFullYear(), date.getMonth(), 1)
     return {
       selectedDate: {
-        start: new Date(date.getFullYear(), date.getMonth(), 1),
+        start: start,
         end: new Date()
+      },
+      stringDateRang: {
+        start: start.toISOString(),
+        end: new Date().toISOString()
       }
     }
   },
@@ -87,6 +105,15 @@ export default {
         end: dates.end,
         showDateText: true
       }
+      console.log(this.selectedDate)
+    },
+    setStringDateRange (dates) {
+      this.stringDateRang = {
+        start: dates.start.toISOString(),
+        end: dates.end.toISOString(),
+        showDateText: true
+      }
+      console.log(this.stringDateRang)
     }
   }
 }

--- a/src/components/VueDatePicker.vue
+++ b/src/components/VueDatePicker.vue
@@ -110,8 +110,8 @@ export default {
     dateRange: {
       type: Object,
       validator: function (input) {
-        const startIsDate = input.start instanceof Date
-        const endIsDate = input.end instanceof Date
+        const startIsDate = input.start instanceof Date || String
+        const endIsDate = input.end instanceof Date || String
         return startIsDate && endIsDate
       },
       default: function () {
@@ -168,8 +168,18 @@ export default {
       }
     },
     getSelectedDate () {
-      const start = this.dateRange.start instanceof Date ? this.dateRange.start : new Date()
-      const end = this.dateRange.end instanceof Date ? this.dateRange.end : new Date()
+      let start = new Date()
+      let end = new Date()
+      if (typeof this.dateRange.start === 'string') {
+        start = new Date(this.dateRange.start)
+      } else if (this.dateRange.start instanceof Date) {
+        start = this.dateRange.start
+      }
+      if (typeof this.dateRange.end === 'string') {
+        end = new Date(this.dateRange.end)
+      } else if (this.dateRange.end instanceof Date) {
+        end = this.dateRange.end
+      }
       return {
         start: start,
         end: end
@@ -200,7 +210,8 @@ export default {
       this.appliedEnd = this.selectedDate.end
       const dates = {
         start: this.selectedDate.start,
-        end: this.selectedDate.end
+        end: this.selectedDate.end,
+        showDateText: true
       }
       this.$emit('get-dates', dates)
       this.visableBox = false


### PR DESCRIPTION
date-range prop now can take either iso string or date object. it also gives back showDateText: true
by default. This makes it easier to pass in date-range properties from vuex storage.